### PR TITLE
filter/bpf_filter.c: include stdint.h header

### DIFF
--- a/filter/bpf_filter.c
+++ b/filter/bpf_filter.c
@@ -34,6 +34,7 @@
  *      @(#)bpf_filter.c	8.1 (Berkeley) 6/10/93
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <strings.h>
 


### PR DESCRIPTION
Since on latest ubuntu/gcc build fails with:
```
filter/bpf_filter.c:109:10: error: ‘intptr_t’ undeclared (first use in this function); did you mean ‘__intptr_t’?
    if (((intptr_t)(p + k) & 3) != 0)
          ^~~~~~~~
          __intptr_t
```