### PR TITLE
Add a method to Builder to append raw BPF instructions

### DIFF
--- a/filter/bpf_builder.go
+++ b/filter/bpf_builder.go
@@ -300,3 +300,9 @@ func (b *Builder) TXA() *Builder {
     b.filter.append_insn(code, 0, 0, 0)
     return b
 }
+
+// Append a raw BPF instruction
+func (b *Builder) AppendInstruction(code Code, jt, jf uint8, k uint32) *Builder {
+    b.filter.append_insn(code, jt, jf, k)
+    return b
+}

--- a/filter/bpf_builder_test.go
+++ b/filter/bpf_builder_test.go
@@ -64,6 +64,19 @@ func TestARP(t *testing.T) {
     }
 }
 
+func TestARPcBPF(t *testing.T) {
+    arp := filter.NewBuilder().
+    AppendInstruction(40, 0, 0, 12).
+    AppendInstruction(21, 0, 1, 2054).
+    AppendInstruction(6, 0, 0, 262144).
+    AppendInstruction(6, 0, 0, 0).
+    Build()
+
+    if arp.String() != test_arp {
+        t.Fatalf("Program mismatch: %s", arp.String())
+    }
+}
+
 var test_dns = `{ 0x00,   0,   0, 0x00000014 },
 { 0xb1,   0,   0, 0x00000000 },
 { 0x0c,   0,   0, 0x00000000 },


### PR DESCRIPTION
This is useful for cases where we already have cBPF program for example
from the output of `tcpdump -ddd` and want to build a Filter using that
program.